### PR TITLE
Implement UUID version 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ script:
 after_success: |
   [ $TRAVIS_BRANCH = master ] &&
   [ $TRAVIS_PULL_REQUEST = false ] &&
+  cargo doc --features="v5" &&  # build a full documentation
   echo '<meta http-equiv=refresh content=0;url=uuid/index.html>' > target/doc/index.html &&
   pip install ghp-import --user $USER &&
   $HOME/.local/bin/ghp-import -n target/doc &&

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: rust
 sudo: false
 script:
-  - cargo build --verbose --features="v5"
-  - cargo test --verbose --features="v5"
-  - cargo doc --features="v5"
+  - cargo build --verbose --features="$FEATURE"
+  - cargo test --verbose --features="$FEATURE"
+  - cargo doc --features="$FEATURE"
 after_success: |
   [ $TRAVIS_BRANCH = master ] &&
   [ $TRAVIS_PULL_REQUEST = false ] &&
@@ -14,6 +14,9 @@ after_success: |
 env:
   global:
     secure: OiQj6NSyu634pS+qWCAeaibuBdiRsDMz5k0bi8hhdom3W24L8I9KkdWlBm2K8Ef97Uzgg6Xsr7LSWX0CONxX2eU3QaB1v3mXNxModa7ftW/w9y7B8MThxS5nRTUmHZC17OvoQ3EoNyrktnTAkyIr0E0YxBruJYAi4EH+54guRN8=
+  matrix:
+    - FEATURE=""
+    - FEATURE="v5"
 notifications:
   email:
     on_success: never

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: rust
 sudo: false
 script:
-  - cargo build --verbose
-  - cargo test --verbose
-  - cargo doc
+  - cargo build --verbose --features="v5"
+  - cargo test --verbose --features="v5"
+  - cargo doc --features="v5"
 after_success: |
   [ $TRAVIS_BRANCH = master ] &&
   [ $TRAVIS_PULL_REQUEST = false ] &&

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,13 @@ description = """
 A library to generate and parse UUIDs.
 """
 
+[features]
+v5 = ["sha1"]
+
 [dependencies]
 rustc-serialize = "0.3"
 rand = "0.3"
+
+[dependencies.sha1]
+version = "0.1.0"
+optional = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,4 @@ v5 = ["sha1"]
 [dependencies]
 rustc-serialize = "0.3"
 rand = "0.3"
-
-[dependencies.sha1]
-version = "0.1.0"
-optional = true
+sha1 = { version = "0.1.0", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,6 +63,9 @@
 extern crate test;
 extern crate rustc_serialize;
 extern crate rand;
+#[cfg(feature = "v5")]
+extern crate sha1;
+
 
 use std::default::Default;
 use std::fmt;
@@ -73,6 +76,8 @@ use std::str::FromStr;
 
 use rand::Rng;
 use rustc_serialize::{Encoder, Encodable, Decoder, Decodable};
+#[cfg(feature = "v5")]
+use sha1::Sha1;
 
 /// A 128-bit (16 byte) buffer containing the ID
 pub type UuidBytes = [u8; 16];
@@ -111,6 +116,31 @@ pub struct Uuid {
     /// The 128-bit number stored in 16 bytes
     bytes: UuidBytes
 }
+
+/// A UUID of the namespace of fully-qualified domain names
+pub const NAMESPACE_DNS: Uuid = Uuid {
+    bytes: [0x6b, 0xa7, 0xb8, 0x10, 0x9d, 0xad, 0x11, 0xd1,
+            0x80, 0xb4, 0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8]
+};
+
+/// A UUID of the namespace of URLs
+pub const NAMESPACE_URL: Uuid = Uuid {
+    bytes: [0x6b, 0xa7, 0xb8, 0x11, 0x9d, 0xad, 0x11, 0xd1,
+            0x80, 0xb4, 0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8]
+};
+
+/// A UUID of the namespace of ISO OIDs
+pub const NAMESPACE_OID: Uuid = Uuid {
+    bytes: [0x6b, 0xa7, 0xb8, 0x12, 0x9d, 0xad, 0x11, 0xd1,
+            0x80, 0xb4, 0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8]
+};
+
+/// A UUID of the namespace of X.500 DNs (in DER or a text output format)
+pub const NAMESPACE_X500: Uuid = Uuid {
+    bytes: [0x6b, 0xa7, 0xb8, 0x14, 0x9d, 0xad, 0x11, 0xd1,
+            0x80, 0xb4, 0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8]
+};
+
 
 impl hash::Hash for Uuid {
     fn hash<S: hash::Hasher>(&self, state: &mut S) {
@@ -191,6 +221,21 @@ impl Uuid {
         copy_memory(&mut uuid.bytes, &ub);
         uuid.set_variant(UuidVariant::RFC4122);
         uuid.set_version(UuidVersion::Random);
+        uuid
+    }
+
+    /// Creates a UUID using a name from a namespace, based on the SHA-1 hash
+    #[cfg(feature = "v5")]
+    pub fn new_v5(namespace: &Uuid, name: &str) -> Uuid {
+        let mut hash = Sha1::new();
+        hash.update(namespace.as_bytes());
+        hash.update(name.as_bytes());
+        let mut buffer: [u8; 20] = [0; 20];
+        hash.output(&mut buffer);
+        let mut uuid = Uuid { bytes: [0; 16] };
+        copy_memory(&mut uuid.bytes, &buffer[..16]);
+        uuid.set_variant(UuidVariant::RFC4122);
+        uuid.set_version(UuidVersion::Sha1);
         uuid
     }
 
@@ -497,8 +542,29 @@ impl rand::Rand for Uuid {
 
 #[cfg(test)]
 mod tests {
+    use super::{NAMESPACE_DNS, NAMESPACE_URL, NAMESPACE_OID, NAMESPACE_X500};
     use super::{Uuid, UuidVariant, UuidVersion};
     use rand;
+
+    #[cfg(feature = "v5")]
+    static FIXTURE_V5: &'static [(&'static Uuid, &'static str, &'static str)] = &[
+        (&NAMESPACE_DNS, "example.org",    "aad03681-8b63-5304-89e0-8ca8f49461b5"),
+        (&NAMESPACE_DNS, "rust-lang.org",  "c66bbb60-d62e-5f17-a399-3a0bd237c503"),
+        (&NAMESPACE_DNS, "42",             "7c411b5e-9d3f-50b5-9c28-62096e41c4ed"),
+        (&NAMESPACE_DNS, "lorem ipsum",    "97886a05-8a68-5743-ad55-56ab2d61cf7b"),
+        (&NAMESPACE_URL, "example.org",    "54a35416-963c-5dd6-a1e2-5ab7bb5bafc7"),
+        (&NAMESPACE_URL, "rust-lang.org",  "c48d927f-4122-5413-968c-598b1780e749"),
+        (&NAMESPACE_URL, "42",             "5c2b23de-4bad-58ee-a4b3-f22f3b9cfd7d"),
+        (&NAMESPACE_URL, "lorem ipsum",    "15c67689-4b85-5253-86b4-49fbb138569f"),
+        (&NAMESPACE_OID, "example.org",    "34784df9-b065-5094-92c7-00bb3da97a30"),
+        (&NAMESPACE_OID, "rust-lang.org",  "8ef61ecb-977a-5844-ab0f-c25ef9b8d5d6"),
+        (&NAMESPACE_OID, "42",             "ba293c61-ad33-57b9-9671-f3319f57d789"),
+        (&NAMESPACE_OID, "lorem ipsum",    "6485290d-f79e-5380-9e64-cb4312c7b4a6"),
+        (&NAMESPACE_X500, "example.org",   "e3635e86-f82b-5bbc-a54a-da97923e5c76"),
+        (&NAMESPACE_X500, "rust-lang.org", "26c9c3e9-49b7-56da-8b9f-a0fb916a71a3"),
+        (&NAMESPACE_X500, "42",            "e4b88014-47c6-5fe0-a195-13710e5f6e27"),
+        (&NAMESPACE_X500, "lorem ipsum",   "b11f79a5-1e6d-57ce-a4b5-ba8531ea03d0"),
+    ];
 
     #[test]
     fn test_nil() {
@@ -533,12 +599,39 @@ mod tests {
         assert!(uuid1.get_variant().unwrap() == UuidVariant::RFC4122);
     }
 
+    #[cfg(feature = "v5")]
     #[test]
-    fn test_get_version() {
+    fn test_new_v5() {
+        for &(ref ns, ref name, _) in FIXTURE_V5 {
+            let uuid = Uuid::new_v5(*ns, *name);
+            assert!(uuid.get_version().unwrap() == UuidVersion::Sha1);
+            assert!(uuid.get_variant().unwrap() == UuidVariant::RFC4122);
+        }
+    }
+
+    #[test]
+    fn test_predefined_namespaces() {
+        assert_eq!(NAMESPACE_DNS.to_hyphenated_string(), "6ba7b810-9dad-11d1-80b4-00c04fd430c8");
+        assert_eq!(NAMESPACE_URL.to_hyphenated_string(), "6ba7b811-9dad-11d1-80b4-00c04fd430c8");
+        assert_eq!(NAMESPACE_OID.to_hyphenated_string(), "6ba7b812-9dad-11d1-80b4-00c04fd430c8");
+        assert_eq!(NAMESPACE_X500.to_hyphenated_string(), "6ba7b814-9dad-11d1-80b4-00c04fd430c8");
+    }
+
+    #[test]
+    fn test_get_version_v4() {
         let uuid1 = Uuid::new_v4();
 
         assert!(uuid1.get_version().unwrap() == UuidVersion::Random);
-        assert!(uuid1.get_version_num() == 4);
+        assert_eq!(uuid1.get_version_num(), 4);
+    }
+
+    #[cfg(feature = "v5")]
+    #[test]
+    fn test_get_version_v5() {
+        let uuid2 = Uuid::new_v5(&NAMESPACE_DNS, "rust-lang.org");
+
+        assert!(uuid2.get_version().unwrap() == UuidVersion::Sha1);
+        assert_eq!(uuid2.get_version_num(), 5);
     }
 
     #[test]
@@ -637,6 +730,15 @@ mod tests {
 
         assert!(s.len() == 36);
         assert!(s.chars().all(|c| c.is_digit(16) || c == '-'));
+    }
+
+    #[cfg(feature = "v5")]
+    #[test]
+    fn test_v5_to_hypenated_string() {
+        for &(ref ns, ref name, ref expected) in FIXTURE_V5 {
+            let uuid = Uuid::new_v5(*ns, *name);
+            assert_eq!(uuid.to_hyphenated_string(), *expected);
+        }
     }
 
     #[test]


### PR DESCRIPTION
Because a SHA-1 hash library should be required to implement the UUID version 5, I described it as an additional feature on `Cargo.toml`.