### PR TITLE
Expand the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,16 @@
 uuid
 ====
 
+[![Build Status](https://travis-ci.org/rust-lang-nursery/uuid.svg?branch=master)](https://travis-ci.org/rust-lang-nursery/uuid)
+[![](http://meritbadge.herokuapp.com/uuid)](https://crates.io/crates/uuid)
+
 A Rust library to generate and parse UUIDs.
 
-[![Build Status](https://travis-ci.org/rust-lang-nursery/uuid.svg?branch=master)](https://travis-ci.org/rust-lang-nursery/uuid)
+Provides support for Universally Unique Identifiers (UUIDs). A UUID is a unique 128-bit number, stored as 16 octets. UUIDs are used to assign unique identifiers to entities without requiring a central allocating authority.
+
+They are particularly useful in distributed systems, though can be used in disparate areas, such as databases and network protocols. Typically a UUID is displayed in a readable string form as a sequence of hexadecimal digits, separated into groups by hyphens.
+
+The uniqueness property is not strictly guaranteed, however for all practical purposes, it can be assumed that an unintentional collision would be extremely unlikely.
 
 [Documentation](https://doc.rust-lang.org/uuid)
 
@@ -22,3 +29,41 @@ and this to your crate root:
 ```rust
 extern crate uuid;
 ```
+
+## Examples
+
+To create a new random (V4) UUID and print it out in hexadecimal form:
+
+```rust
+use uuid::Uuid;
+
+fn main() {
+    let my_uuid = Uuid::new_v4();
+    println!("{}", my_uuid.to_string());
+}
+```
+
+The library supports 5 versions of UUID:
+
+Name     | Version
+---------|----------
+Mac	     | Version 1: MAC address
+Dce	     | Version 2: DCE Security
+Md5	     | Version 3: MD5 hash
+Random   | Version 4: Random
+Sha1     | Version 5: SHA-1 hash
+
+To create a new UUID by specifying the format and printing a hyphenated string:
+
+```rust
+use uuid::{Uuid, UuidVersion};
+
+fn main() {
+    let my_uuid = Uuid::new(UuidVersion { Sha1 }).unwrap();
+    println!("{}", my_uuid.to_hyphenated_string());
+}
+```
+
+## References
+
+[Wikipedia: Universally Unique Identifier](https://en.wikipedia.org/wiki/Universally_unique_identifier)

--- a/README.md
+++ b/README.md
@@ -6,11 +6,18 @@ uuid
 
 A Rust library to generate and parse UUIDs.
 
-Provides support for Universally Unique Identifiers (UUIDs). A UUID is a unique 128-bit number, stored as 16 octets. UUIDs are used to assign unique identifiers to entities without requiring a central allocating authority.
+Provides support for Universally Unique Identifiers (UUIDs). A UUID is a unique
+128-bit number, stored as 16 octets. UUIDs are used to assign unique identifiers
+to entities without requiring a central allocating authority.
 
-They are particularly useful in distributed systems, though can be used in disparate areas, such as databases and network protocols. Typically a UUID is displayed in a readable string form as a sequence of hexadecimal digits, separated into groups by hyphens.
+They are particularly useful in distributed systems, though can be used in
+disparate areas, such as databases and network protocols. Typically a UUID is
+displayed in a readable string form as a sequence of hexadecimal digits,
+separated into groups by hyphens.
 
-The uniqueness property is not strictly guaranteed, however for all practical purposes, it can be assumed that an unintentional collision would be extremely unlikely.
+The uniqueness property is not strictly guaranteed, however for all practical
+purposes, it can be assumed that an unintentional collision would be extremely
+unlikely.
 
 [Documentation](https://doc.rust-lang.org/uuid)
 
@@ -47,20 +54,21 @@ The library supports 5 versions of UUID:
 
 Name     | Version
 ---------|----------
-Mac	     | Version 1: MAC address
-Dce	     | Version 2: DCE Security
-Md5	     | Version 3: MD5 hash
+Mac      | Version 1: MAC address
+Dce      | Version 2: DCE Security
+Md5      | Version 3: MD5 hash
 Random   | Version 4: Random
 Sha1     | Version 5: SHA-1 hash
 
-To create a new UUID by specifying the format and printing a hyphenated string:
+To parse a simple UUID, then print the version and urn string format:
 
 ```rust
-use uuid::{Uuid, UuidVersion};
+use uuid::Uuid;
 
 fn main() {
-    let my_uuid = Uuid::new(UuidVersion { Sha1 }).unwrap();
-    println!("{}", my_uuid.to_hyphenated_string());
+    let my_uuid = Uuid::parse_str("936DA01F9ABD4d9d80C702AF85C822A8").unwrap();
+    println!("Parsed a version {} UUID.", my_uuid.get_version_num());
+    println!("{}", my_uuid.to_urn_string());
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ use uuid::Uuid;
 
 fn main() {
     let my_uuid = Uuid::new_v4();
-    println!("{}", my_uuid.to_string());
+    println!("{}", my_uuid);
 }
 ```
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,8 +31,19 @@
 //! use uuid::Uuid;
 //!
 //! fn main() {
-//!     let uuid1 = Uuid::new_v4();
-//!     println!("{}", uuid1.to_string());
+//!     let my_uuid = Uuid::new_v4();
+//!     println!("{}", my_uuid);
+//! }
+//! ```
+//!
+//! To parse parse a UUID in the simple format and print it as a urn:
+//!
+//! ```rust
+//! use uuid::Uuid;
+//!
+//! fn main() {
+//!     let my_uuid = Uuid::parse_str("936DA01F9ABD4d9d80C702AF85C822A8").unwrap();
+//!     println!("{}", my_uuid.to_urn_string());
 //! }
 //! ```
 //!


### PR DESCRIPTION
The current readme file is sparse and forces users into the documentation for even the simplest use case.

This commit expands the readme with some of the basics from the documentation, providing a better first impression of the library and it's capabilities.