### PR TITLE
Replace use of unwrap to improve safety

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,6 +151,7 @@ pub enum ParseError {
     InvalidCharacter(char, usize),
     InvalidGroups(usize),
     InvalidGroupLength(usize, usize, u8),
+    Unknown,
 }
 
 /// Converts a ParseError to a string
@@ -177,6 +178,8 @@ impl fmt::Display for ParseError {
                        group,
                        found,
                        expecting),
+            ParseError::Unknown =>
+                write!(f, "Parsing failed for unknown reason"),
         }
     }
 }
@@ -456,7 +459,7 @@ impl Uuid {
                                                       GROUP_LENS[4]));
         }
 
-        Ok(Uuid::from_bytes(&mut buffer).unwrap())
+        Uuid::from_bytes(&mut buffer).ok_or(ParseError::Unknown)
     }
 
     /// Tests if the UUID is nil


### PR DESCRIPTION
This replaces the use of `.unwrap()` with `.ok_or(_)` to ensure
that a result is returned instead of allowing a possible panic.

A possible problem with this is that it does add an item to the ParseError enum, which is a breaking change.