### PR TITLE
Update dependency `serde` to version 0.7.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,5 +14,5 @@ A library to generate and parse UUIDs.
 
 [dependencies]
 rustc-serialize = "0.3"
-serde = { version = "^0.6.0", optional = true }
+serde = { version = "^0.7.0", optional = true }
 rand = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -534,7 +534,7 @@ impl Decodable for Uuid {
 #[cfg(feature = "serde")]
 impl Serialize for Uuid {
     fn serialize<S: Serializer>(&self, serializer: &mut S) -> Result<(), S::Error> {
-        serializer.visit_str(&self.to_hyphenated_string())
+        serializer.serialize_str(&self.to_hyphenated_string())
     }
 }
 
@@ -547,15 +547,15 @@ impl Deserialize for Uuid {
             type Value = Uuid;
 
             fn visit_str<E: de::Error>(&mut self, value: &str) -> Result<Uuid, E> {
-                value.parse().map_err(|err| E::syntax(&format!("{}", err)))
+                value.parse().map_err(|err| E::custom(format!("{}", err)))
             }
 
             fn visit_bytes<E: de::Error>(&mut self, value: &[u8]) -> Result<Uuid, E> {
-                Uuid::from_bytes(value).ok_or(E::syntax("Expected 16 bytes."))
+                Uuid::from_bytes(value).ok_or(E::custom("Expected 16 bytes."))
             }
         }
 
-        deserializer.visit(UuidVisitor)
+        deserializer.deserialize(UuidVisitor)
     }
 }
 


### PR DESCRIPTION
This update isn't semver-compatible since it breaks users of `uuid` who use `serde = ^0.6.0`. Therefore we should raise the minior instead of patch I think. What is the common consensus in the rust ecosystem?