### PR TITLE
Implement `Ord` and `PartialOrd` for `Uuid`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,7 +154,7 @@ pub enum UuidVariant {
 }
 
 /// A Universally Unique Identifier (UUID)
-#[derive(Copy, Clone, PartialEq, Eq)]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Uuid {
     /// The 128-bit number stored in 16 bytes
     bytes: UuidBytes,


### PR DESCRIPTION
Useful as it allows a UUID to be used as a key for a BTreeMap, which wasn't possible before.

This is accomplished by using the underlying byte array's builtin Ord/PartialOrd implementations.