### PR TITLE
added Uuid v1 with random node support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ A library to generate and parse UUIDs.
 rustc-serialize = { version = "0.3", optional = true }
 serde = { version = "^0.7.0", optional = true }
 rand = { version = "0.3", optional = true }
-time = "0.1"
 
 [features]
 use_std = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,9 @@ A library to generate and parse UUIDs.
 rustc-serialize = { version = "0.3", optional = true }
 serde = { version = "^0.7.0", optional = true }
 rand = { version = "0.3", optional = true }
+time = "0.1"
 
 [features]
 use_std = []
 v4 = ["rand"]
+v1 = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -270,15 +270,17 @@ impl Uuid {
     /// TODO: generate node use real MAC address
     #[cfg(feature = "v1")]
     pub fn fill_node(node: &mut [u8]) {
-        static mut static_node: [u8; 6] = [0xff; 6];
+        static mut static_node: [u8; 6] = [0u8; 6];
         static NODE: Once = ONCE_INIT;
 
         // init static_node
         unsafe {
-            NODE.call_once(|| {
-                static_node = rand::thread_rng().gen();
-                static_node[0] = static_node[0] | 0x01;
-            });
+            if static_node[0] == 0u8 {
+                NODE.call_once(|| {
+                    static_node = rand::thread_rng().gen();
+                    static_node[0] = static_node[0] | 0x01;
+                });
+            }
         }
 
         // fill node via argument
@@ -298,8 +300,8 @@ impl Uuid {
     /// TODO: support the real MAC address
     #[cfg(feature = "v1")]
     pub fn new_v1_of(given_node: Option<&[u8; 6]>,
-                  given_clock_seq: Option<&[u8; 2]>)
-                  -> Uuid {
+                     given_clock_seq: Option<&[u8; 2]>)
+                     -> Uuid {
         let timestamp = Uuid::get_timestamp();
         let time_low = timestamp & 0xffffffff;
         let time_mid = (timestamp >> 32) & 0xffff;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -273,7 +273,7 @@ impl Uuid {
         unsafe {
             // init last two bytes,
             if random_node[5] == 0 {
-                random_node[0] = rand::thread_rng().gen::<u8>();
+                random_node[0] = rand::thread_rng().gen::<u8>() | 0x01;
                 random_node[1] = rand::thread_rng().gen::<u8>();
                 random_node[2] = rand::thread_rng().gen::<u8>();
                 random_node[3] = rand::thread_rng().gen::<u8>();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -297,7 +297,7 @@ impl Uuid {
     ///
     /// TODO: support the real MAC address
     #[cfg(feature = "v1")]
-    pub fn get_v1(given_node: Option<&[u8; 6]>,
+    pub fn new_v1_of(given_node: Option<&[u8; 6]>,
                   given_clock_seq: Option<&[u8; 2]>)
                   -> Uuid {
         let timestamp = Uuid::get_timestamp();
@@ -347,7 +347,7 @@ impl Uuid {
     /// TODO: support to use the real MAC address
     #[cfg(feature = "v1")]
     pub fn new_v1() -> Uuid {
-        Uuid::get_v1(None, None)
+        Uuid::new_v1_of(None, None)
     }
 
     /// Creates a new random UUID


### PR DESCRIPTION
added Uuid v1 with random node support
TODO: support generate node with a real MAC.

In fact in some situations such as in docker, the MAC is virtual. so I think to use a random node seem to be ok then.

please refer to: https://docs.docker.com/v1.8/articles/networking/