### PR TITLE
Fix for bincode deserialize

### DIFF
--- a/src/serde.rs
+++ b/src/serde.rs
@@ -29,5 +29,7 @@ impl Deserialize for Uuid {
         }
 
         deserializer.deserialize(UuidVisitor)
+                    .or_else(|_| deserializer.deserialize_string(UuidVisitor))
+                    .or_else(|_| deserializer.deserialize_bytes(UuidVisitor))
     }
 }


### PR DESCRIPTION
Blocks https://github.com/servo/servo/pull/12898, because ipc-channel uses bincode, which doesn't use the default `deserialize`: https://github.com/TyOverby/bincode/blob/master/src/serde/reader.rs#L192.

With this change, the following test snippet can work:

```rust
extern crate bincode;
extern crate uuid;
extern crate serde;

#[cfg(test)]
mod tests {
    use uuid::Uuid;
    use bincode::serde::*;
    use bincode::SizeLimit;

    #[test]
    fn it_works() {
        let id = Uuid::new_v4();

        let bytes = serialize(&id, SizeLimit::Infinite).unwrap();

        let id_: Uuid = deserialize(&bytes).unwrap();

        assert_eq!(id, id_);
    }
}
```