### PR TITLE
Enable Serde features in no_std environment

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,6 @@ rand = { version = "0.3", optional = true }
 sha1 = { version = "0.2", optional = true }
 
 [features]
-use_std = []
+use_std = ["serde/std"] # pull in serde's std support with our own
 v4 = ["rand"]
 v5 = ["sha1"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ A library to generate and parse UUIDs.
 
 [dependencies]
 rustc-serialize = { version = "0.3", optional = true }
-serde = { version = "0.8", optional = true, default-features = false }
+serde = { version = "0.8", optional = true, default-features = false, features = ["collections"] }
 rand = { version = "0.3", optional = true }
 sha1 = { version = "0.2", optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ A library to generate and parse UUIDs.
 
 [dependencies]
 rustc-serialize = { version = "0.3", optional = true }
-serde = { version = "0.8", optional = true }
+serde = { version = "0.8", optional = true, default-features = false }
 rand = { version = "0.3", optional = true }
 sha1 = { version = "0.2", optional = true }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,8 +114,8 @@ use core::fmt;
 use core::hash;
 use core::str::FromStr;
 
-// rustc-serialize and serde link to std, so go ahead an pull in our own std
-// support in those situations as well.
+// rustc-serialize links to std, so go ahead an pull in our own std support in
+// those situations as well.
 #[cfg(any(feature = "use_std",
           feature = "rustc-serialize"))]
 mod std_support;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,8 +116,7 @@ use core::str::FromStr;
 // rustc-serialize and serde link to std, so go ahead an pull in our own std
 // support in those situations as well.
 #[cfg(any(feature = "use_std",
-          feature = "rustc-serialize",
-          feature = "serde"))]
+          feature = "rustc-serialize"))]
 mod std_support;
 #[cfg(feature = "rustc-serialize")]
 mod rustc_serialize;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,7 +115,7 @@ use core::hash;
 use core::str::FromStr;
 
 // rustc-serialize links to std, so go ahead an pull in our own std support in
-// those situations as well.
+// that situation as well.
 #[cfg(any(feature = "use_std",
           feature = "rustc-serialize"))]
 mod std_support;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,7 +99,8 @@
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "https://www.rust-lang.org/favicon.ico",
        html_root_url = "https://doc.rust-lang.org/uuid/")]
-
+#![cfg_attr(feature = "serde", feature(collections))]
+#![feature(lang_items)]
 #![deny(warnings)]
 #![no_std]
 

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -1,8 +1,8 @@
 extern crate serde;
-extern crate std;
+extern crate collections;
 
-use self::std::prelude::v1::*;
 use self::serde::{de, Deserialize, Deserializer, Serialize, Serializer};
+use self::collections::string::ToString;
 
 use Uuid;
 


### PR DESCRIPTION
I ran into a situation where I wanted serde support without also pulling in std. Only a few changes are required, which I think are pretty low-risk, because if somebody depends on serde's std feature at any level, it will get built in.