### PR TITLE
Add support for Rocket FromParam

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,12 +22,13 @@ env:
 
   matrix:
     - FEATURES=""
+    - FEATURES="rocket"
     - FEATURES="rustc-serialize"
     - FEATURES="serde"
     - FEATURES="use_std"
     - FEATURES="v4"
     - FEATURES="v5"
-    - FEATURES="rustc-serialize serde v4 v5 use_std"
+    - FEATURES="rocket rustc-serialize serde v4 v5 use_std"
 notifications:
   email:
     on_success: never

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ rustc-serialize = { version = "0.3", optional = true }
 serde = { version = "0.8", optional = true }
 rand = { version = "0.3", optional = true }
 sha1 = { version = "0.2", optional = true }
+rocket = { version = "0.1", optional = true }
 
 [features]
 use_std = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,8 @@
 //!   using the `rustc-serialize` crate.
 //! * `serde` - adds the ability to serialize and deserialize a `Uuid` using the
 //!   `serde` crate.
+//! * `rocket` - adds the ability to use an `Uuid` as a `FromParam` using the
+//!   `rocket` crate.
 //!
 //! By default, `uuid` can be depended on with:
 //!
@@ -123,6 +125,8 @@ mod std_support;
 mod rustc_serialize;
 #[cfg(feature = "serde")]
 mod serde;
+#[cfg(feature = "rocket")]
+mod rocket;
 
 #[cfg(feature = "v4")]
 use rand::Rng;

--- a/src/rocket.rs
+++ b/src/rocket.rs
@@ -1,0 +1,27 @@
+extern crate rocket;
+
+use Uuid;
+use ParseError;
+use self::rocket::request::FromParam;
+
+impl<'a> FromParam<'a> for Uuid {
+    type Error = ParseError;
+
+    fn from_param(param: &'a str) -> Result<Self, Self::Error> {
+        Uuid::parse_str(param)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::rocket::request::FromParam;
+    use Uuid;
+
+    #[test]
+    fn test_serialize_round_trip() {
+        assert_eq!(
+            Uuid::from_param("C9344778-FC32-4151-82B1-DA78601584FB").unwrap(),
+            Uuid::parse_str("C9344778-FC32-4151-82B1-DA78601584FB").unwrap()
+        )
+    }
+}


### PR DESCRIPTION
This PR adds support for using UUIDs as URL parameters in [Rocket](https://rocket.rs).

Example usage:

**src/main.rs**

```rust
#![feature(plugin)]
#![plugin(rocket_codegen)]

extern crate rocket;
extern crate uuid;

use uuid::Uuid;

#[get("/hello/<id>")]
fn hello(id: Uuid) -> String {
    format!("Hello, {}!", id)
}

fn main() {
    rocket::ignite().mount("/", routes![hello]).launch();
}
```

**Cargo.toml**

```toml
[package]
authors = ["Linus Unnebäck <linus@folkdatorn.se>"]
name = "uuid-rocket-example"
version = "0.1.0"

[dependencies]
rocket = "0.1.5"
rocket_codegen = "0.1.5"

[dependencies.uuid]
git = "https://github.com/LinusU/uuid"
rev = "b2e3f49"
features = ["rocket"]
```