### PR TITLE
Bump version to 0.4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "uuid"
-version = "0.3.1"
+version = "0.4.0"
 authors = ["The Rust Project Developers"]
 license = "MIT/Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
The Serde 0.9 update was a breaking change.