### PR TITLE
Update to serde 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ A library to generate and parse UUIDs.
 
 [dependencies]
 rustc-serialize = { version = "0.3", optional = true }
-serde = { version = "0.9", optional = true }
+serde = { version = "1.0", optional = true }
 rand = { version = "0.3", optional = true }
 sha1 = { version = "0.2", optional = true }
 

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -13,11 +13,11 @@ impl Serialize for Uuid {
     }
 }
 
-impl Deserialize for Uuid {
-    fn deserialize<D: Deserializer>(deserializer: D) -> Result<Self, D::Error> {
+impl<'de> Deserialize<'de> for Uuid {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         struct UuidVisitor;
 
-        impl de::Visitor for UuidVisitor {
+        impl<'vi> de::Visitor<'vi> for UuidVisitor {
             type Value = Uuid;
 
             fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {


### PR DESCRIPTION
Deserialize and Visitor now requires a lifetime... just a small update to add this.