### PR TITLE
Hash implementations from RustCrypto

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,8 @@ all-features = true
 rustc-serialize = { version = "0.3", optional = true }
 serde = { version = "1.0", optional = true }
 rand = { version = "0.3", optional = true }
-sha-1 = { version = "0.4", optional = true }
-md-5 = { version = "0.5", optional = true }
+sha-1 = { version = "^0.4.1", optional = true, default-features = false }
+md-5 = { version = "^0.5.2", optional = true, default-features = false }
 
 [features]
 use_std = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,11 +19,7 @@ all-features = true
 rustc-serialize = { version = "0.3", optional = true }
 serde = { version = "1.0", optional = true }
 rand = { version = "0.3", optional = true }
-sha-1 = { version = "^0.4.1", optional = true, default-features = false }
-md-5 = { version = "^0.5.2", optional = true, default-features = false }
 
 [features]
 use_std = []
-v3 = ["md-5"]
 v4 = ["rand"]
-v5 = ["sha-1"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,11 +19,11 @@ all-features = true
 rustc-serialize = { version = "0.3", optional = true }
 serde = { version = "1.0", optional = true }
 rand = { version = "0.3", optional = true }
-sha1 = { version = "0.2", optional = true }
-md5 = { version = "0.3", optional = true }
+sha-1 = { version = "0.4", optional = true }
+md-5 = { version = "0.5", optional = true }
 
 [features]
 use_std = []
-v3 = ["md5"]
+v3 = ["md-5"]
 v4 = ["rand"]
-v5 = ["sha1"]
+v5 = ["sha-1"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,4 +22,6 @@ rand = { version = "0.3", optional = true }
 
 [features]
 use_std = []
+v3 = []
 v4 = ["rand"]
+v5 = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,8 +128,12 @@ mod rustc_serialize;
 #[cfg(feature = "serde")]
 mod serde;
 
+#[cfg(feature = "v3")]
+use md5::Md5;
 #[cfg(feature = "v4")]
 use rand::Rng;
+#[cfg(feature = "v5")]
+use sha1::Sha1;
 
 /// A 128-bit (16 byte) buffer containing the ID.
 pub type UuidBytes = [u8; 16];
@@ -310,11 +314,10 @@ impl Uuid {
     /// to be enabled.
     #[cfg(feature = "v3")]
     pub fn new_v3(namespace: &Uuid, name: &str) -> Uuid {
-        use md5::{Md5, Digest};
-        let mut hasher = Md5::new();
-        hasher.input(namespace.as_bytes());
-        hasher.input(name.as_bytes());
-        let hash = hasher.result();
+        let mut hasher = Md5::default();
+        hasher.consume(namespace.as_bytes());
+        hasher.consume(name.as_bytes());
+        let hash = hasher.hash();
         let mut uuid = Uuid { bytes: [0; 16] };
         copy_memory(&mut uuid.bytes, &hash[..16]);
         uuid.set_variant(UuidVariant::RFC4122);
@@ -360,11 +363,10 @@ impl Uuid {
     /// to be enabled.
     #[cfg(feature = "v5")]
     pub fn new_v5(namespace: &Uuid, name: &str) -> Uuid {
-        use sha1::{Sha1, Digest};
-        let mut hasher = Sha1::new();
-        hasher.input(namespace.as_bytes());
-        hasher.input(name.as_bytes());
-        let hash = hasher.result();
+        let mut hasher = Sha1::default();
+        hasher.consume(namespace.as_bytes());
+        hasher.consume(name.as_bytes());
+        let hash = hasher.hash();
         let mut uuid = Uuid { bytes: [0; 16] };
         copy_memory(&mut uuid.bytes, &hash[..16]);
         uuid.set_variant(UuidVariant::RFC4122);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,13 +105,8 @@
 #![deny(warnings)]
 #![no_std]
 
-#[cfg(feature = "v3")]
-extern crate md_5 as md5;
 #[cfg(feature = "v4")]
 extern crate rand;
-#[cfg(feature = "v5")]
-extern crate sha_1 as sha1;
-
 
 use core::fmt;
 use core::hash;
@@ -129,11 +124,11 @@ mod rustc_serialize;
 mod serde;
 
 #[cfg(feature = "v3")]
-use md5::Md5;
+mod md5;
 #[cfg(feature = "v4")]
 use rand::Rng;
 #[cfg(feature = "v5")]
-use sha1::Sha1;
+mod sha1;
 
 /// A 128-bit (16 byte) buffer containing the ID.
 pub type UuidBytes = [u8; 16];
@@ -314,12 +309,7 @@ impl Uuid {
     /// to be enabled.
     #[cfg(feature = "v3")]
     pub fn new_v3(namespace: &Uuid, name: &str) -> Uuid {
-        let mut hasher = Md5::default();
-        hasher.consume(namespace.as_bytes());
-        hasher.consume(name.as_bytes());
-        let hash = hasher.hash();
-        let mut uuid = Uuid { bytes: [0; 16] };
-        copy_memory(&mut uuid.bytes, &hash[..16]);
+        let mut uuid = Uuid { bytes: md5::compute(&namespace.bytes, name) };
         uuid.set_variant(UuidVariant::RFC4122);
         uuid.set_version(UuidVersion::Md5);
         uuid
@@ -363,12 +353,7 @@ impl Uuid {
     /// to be enabled.
     #[cfg(feature = "v5")]
     pub fn new_v5(namespace: &Uuid, name: &str) -> Uuid {
-        let mut hasher = Sha1::default();
-        hasher.consume(namespace.as_bytes());
-        hasher.consume(name.as_bytes());
-        let hash = hasher.hash();
-        let mut uuid = Uuid { bytes: [0; 16] };
-        copy_memory(&mut uuid.bytes, &hash[..16]);
+        let mut uuid = Uuid { bytes: sha1::compute(&namespace.bytes, name) };
         uuid.set_variant(UuidVariant::RFC4122);
         uuid.set_version(UuidVersion::Sha1);
         uuid

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,11 +106,11 @@
 #![no_std]
 
 #[cfg(feature = "v3")]
-extern crate md5;
+extern crate md_5 as md5;
 #[cfg(feature = "v4")]
 extern crate rand;
 #[cfg(feature = "v5")]
-extern crate sha1;
+extern crate sha_1 as sha1;
 
 
 use core::fmt;
@@ -130,8 +130,6 @@ mod serde;
 
 #[cfg(feature = "v4")]
 use rand::Rng;
-#[cfg(feature = "v5")]
-use sha1::Sha1;
 
 /// A 128-bit (16 byte) buffer containing the ID.
 pub type UuidBytes = [u8; 16];
@@ -312,17 +310,18 @@ impl Uuid {
     /// to be enabled.
     #[cfg(feature = "v3")]
     pub fn new_v3(namespace: &Uuid, name: &str) -> Uuid {
-        let mut ctx = md5::Context::new();
-        ctx.consume(namespace.as_bytes());
-        ctx.consume(name.as_bytes());
-        let digest = ctx.compute();
+        use md5::{Md5, Digest};
+        let mut hasher = Md5::new();
+        hasher.input(namespace.as_bytes());
+        hasher.input(name.as_bytes());
+        let hash = hasher.result();
         let mut uuid = Uuid { bytes: [0; 16] };
-        copy_memory(&mut uuid.bytes, &digest[..16]);
+        copy_memory(&mut uuid.bytes, &hash[..16]);
         uuid.set_variant(UuidVariant::RFC4122);
         uuid.set_version(UuidVersion::Md5);
         uuid
     }
-    
+
     /// Creates a random `Uuid`.
     ///
     /// This uses the `rand` crate's default task RNG as the source of random numbers.
@@ -361,12 +360,13 @@ impl Uuid {
     /// to be enabled.
     #[cfg(feature = "v5")]
     pub fn new_v5(namespace: &Uuid, name: &str) -> Uuid {
-        let mut hash = Sha1::new();
-        hash.update(namespace.as_bytes());
-        hash.update(name.as_bytes());
-        let buffer = hash.digest().bytes();
+        use sha1::{Sha1, Digest};
+        let mut hasher = Sha1::new();
+        hasher.input(namespace.as_bytes());
+        hasher.input(name.as_bytes());
+        let hash = hasher.result();
         let mut uuid = Uuid { bytes: [0; 16] };
-        copy_memory(&mut uuid.bytes, &buffer[..16]);
+        copy_memory(&mut uuid.bytes, &hash[..16]);
         uuid.set_variant(UuidVariant::RFC4122);
         uuid.set_version(UuidVersion::Sha1);
         uuid
@@ -1091,7 +1091,7 @@ mod tests {
             assert_eq!(uuid.hyphenated().to_string(), *expected);
         }
     }
-    
+
     #[cfg(feature = "v5")]
     #[test]
     fn test_v5_to_hypenated_string() {

--- a/src/md5.rs
+++ b/src/md5.rs
@@ -1,0 +1,214 @@
+/// Round constants
+const RC: [u32; 64] = [
+    // round 1
+    0xd76aa478, 0xe8c7b756, 0x242070db, 0xc1bdceee,
+    0xf57c0faf, 0x4787c62a, 0xa8304613, 0xfd469501,
+    0x698098d8, 0x8b44f7af, 0xffff5bb1, 0x895cd7be,
+    0x6b901122, 0xfd987193, 0xa679438e, 0x49b40821,
+    // round 2
+    0xf61e2562, 0xc040b340, 0x265e5a51, 0xe9b6c7aa,
+    0xd62f105d, 0x02441453, 0xd8a1e681, 0xe7d3fbc8,
+    0x21e1cde6, 0xc33707d6, 0xf4d50d87, 0x455a14ed,
+    0xa9e3e905, 0xfcefa3f8, 0x676f02d9, 0x8d2a4c8a,
+    // round 3
+    0xfffa3942, 0x8771f681, 0x6d9d6122, 0xfde5380c,
+    0xa4beea44, 0x4bdecfa9, 0xf6bb4b60, 0xbebfbc70,
+    0x289b7ec6, 0xeaa127fa, 0xd4ef3085, 0x04881d05,
+    0xd9d4d039, 0xe6db99e5, 0x1fa27cf8, 0xc4ac5665,
+    // round 4
+    0xf4292244, 0x432aff97, 0xab9423a7, 0xfc93a039,
+    0x655b59c3, 0x8f0ccc92, 0xffeff47d, 0x85845dd1,
+    0x6fa87e4f, 0xfe2ce6e0, 0xa3014314, 0x4e0811a1,
+    0xf7537e82, 0xbd3af235, 0x2ad7d2bb, 0xeb86d391,
+];
+
+/// Init state
+const S0: [u32; 4] = [0x67452301, 0xefcdab89, 0x98badcfe, 0x10325476];
+
+const BLOCK_SIZE: usize = 64;
+
+#[inline(always)]
+fn op_f(w: u32, x: u32, y: u32, z: u32, m: u32, c:u32, s: u32) -> u32 {
+    ((x & y) | (!x & z))
+        .wrapping_add(w).wrapping_add(m).wrapping_add(c)
+        .rotate_left(s).wrapping_add(x)
+}
+#[inline(always)]
+fn op_g(w: u32, x: u32, y: u32, z: u32, m: u32, c:u32, s: u32) -> u32 {
+    ((x & z) | (y & !z))
+        .wrapping_add(w).wrapping_add(m).wrapping_add(c)
+        .rotate_left(s).wrapping_add(x)
+}
+
+#[inline(always)]
+fn op_h(w: u32, x: u32, y: u32, z: u32, m: u32, c:u32, s: u32) -> u32 {
+    (x ^ y ^ z)
+        .wrapping_add(w).wrapping_add(m).wrapping_add(c)
+        .rotate_left(s).wrapping_add(x)
+}
+
+#[inline(always)]
+fn op_i(w: u32, x: u32, y: u32, z: u32, m: u32, c:u32, s: u32) -> u32 {
+    (y ^ (x | !z))
+        .wrapping_add(w).wrapping_add(m).wrapping_add(c)
+        .rotate_left(s).wrapping_add(x)
+}
+
+#[inline(always)]
+fn compress(state: &mut [u32; 4], input: &[u8]) {
+    assert_eq!(input.len(), BLOCK_SIZE);
+    let mut a = state[0];
+    let mut b = state[1];
+    let mut c = state[2];
+    let mut d = state[3];
+
+    let mut data = [0u32; 16];
+
+    for i in 0..data.len() {
+        data[i] = ((input[4*i] as u32) ) |
+                  ((input[4*i + 1] as u32) <<  8) |
+                  ((input[4*i + 2] as u32) << 16) |
+                  ((input[4*i + 3] as u32) << 24);
+    }
+
+    // round 1
+    a = op_f(a, b, c, d, data[0],  RC[0],  7);
+    d = op_f(d, a, b, c, data[1],  RC[1],  12);
+    c = op_f(c, d, a, b, data[2],  RC[2],  17);
+    b = op_f(b, c, d, a, data[3],  RC[3],  22);
+
+    a = op_f(a, b, c, d, data[4],  RC[4],  7);
+    d = op_f(d, a, b, c, data[5],  RC[5],  12);
+    c = op_f(c, d, a, b, data[6],  RC[6],  17);
+    b = op_f(b, c, d, a, data[7],  RC[7],  22);
+
+    a = op_f(a, b, c, d, data[8],  RC[8],  7);
+    d = op_f(d, a, b, c, data[9],  RC[9],  12);
+    c = op_f(c, d, a, b, data[10], RC[10], 17);
+    b = op_f(b, c, d, a, data[11], RC[11], 22);
+
+    a = op_f(a, b, c, d, data[12], RC[12], 7);
+    d = op_f(d, a, b, c, data[13], RC[13], 12);
+    c = op_f(c, d, a, b, data[14], RC[14], 17);
+    b = op_f(b, c, d, a, data[15], RC[15], 22);
+
+    // round 2
+    a = op_g(a, b, c, d, data[1],  RC[16], 5);
+    d = op_g(d, a, b, c, data[6],  RC[17], 9);
+    c = op_g(c, d, a, b, data[11], RC[18], 14);
+    b = op_g(b, c, d, a, data[0],  RC[19], 20);
+
+    a = op_g(a, b, c, d, data[5],  RC[20], 5);
+    d = op_g(d, a, b, c, data[10], RC[21], 9);
+    c = op_g(c, d, a, b, data[15], RC[22], 14);
+    b = op_g(b, c, d, a, data[4],  RC[23], 20);
+
+    a = op_g(a, b, c, d, data[9],  RC[24], 5);
+    d = op_g(d, a, b, c, data[14], RC[25], 9);
+    c = op_g(c, d, a, b, data[3],  RC[26], 14);
+    b = op_g(b, c, d, a, data[8],  RC[27], 20);
+
+    a = op_g(a, b, c, d, data[13], RC[28], 5);
+    d = op_g(d, a, b, c, data[2],  RC[29], 9);
+    c = op_g(c, d, a, b, data[7],  RC[30], 14);
+    b = op_g(b, c, d, a, data[12], RC[31], 20);
+
+    // round 3
+    a = op_h(a, b, c, d, data[5],  RC[32], 4);
+    d = op_h(d, a, b, c, data[8],  RC[33], 11);
+    c = op_h(c, d, a, b, data[11], RC[34], 16);
+    b = op_h(b, c, d, a, data[14], RC[35], 23);
+
+    a = op_h(a, b, c, d, data[1],  RC[36], 4);
+    d = op_h(d, a, b, c, data[4],  RC[37], 11);
+    c = op_h(c, d, a, b, data[7],  RC[38], 16);
+    b = op_h(b, c, d, a, data[10], RC[39], 23);
+
+    a = op_h(a, b, c, d, data[13], RC[40], 4);
+    d = op_h(d, a, b, c, data[0],  RC[41], 11);
+    c = op_h(c, d, a, b, data[3],  RC[42], 16);
+    b = op_h(b, c, d, a, data[6],  RC[43], 23);
+
+    a = op_h(a, b, c, d, data[9],  RC[44], 4);
+    d = op_h(d, a, b, c, data[12], RC[45], 11);
+    c = op_h(c, d, a, b, data[15], RC[46], 16);
+    b = op_h(b, c, d, a, data[2],  RC[47], 23);
+
+    // round 4
+    a = op_i(a, b, c, d, data[0],  RC[48], 6);
+    d = op_i(d, a, b, c, data[7],  RC[49], 10);
+    c = op_i(c, d, a, b, data[14], RC[50], 15);
+    b = op_i(b, c, d, a, data[5],  RC[51], 21);
+
+    a = op_i(a, b, c, d, data[12], RC[52], 6);
+    d = op_i(d, a, b, c, data[3],  RC[53], 10);
+    c = op_i(c, d, a, b, data[10], RC[54], 15);
+    b = op_i(b, c, d, a, data[1],  RC[55], 21);
+
+    a = op_i(a, b, c, d, data[8],  RC[56], 6);
+    d = op_i(d, a, b, c, data[15], RC[57], 10);
+    c = op_i(c, d, a, b, data[6],  RC[58], 15);
+    b = op_i(b, c, d, a, data[13], RC[59], 21);
+
+    a = op_i(a, b, c, d, data[4],  RC[60], 6);
+    d = op_i(d, a, b, c, data[11], RC[61], 10);
+    c = op_i(c, d, a, b, data[2],  RC[62], 15);
+    b = op_i(b, c, d, a, data[9],  RC[63], 21);
+
+    state[0] = state[0].wrapping_add(a);
+    state[1] = state[1].wrapping_add(b);
+    state[2] = state[2].wrapping_add(c);
+    state[3] = state[3].wrapping_add(d);
+}
+
+/// Compute MD5 hash of concatenated namespace and name
+pub fn compute(namespace: &[u8; 16], name: &str) -> [u8; 16] {
+    let mut name = name.as_bytes();
+    let mut state = S0;
+    let mut block = [0u8; BLOCK_SIZE];
+    let mut pos = 16;
+
+    block[..pos].copy_from_slice(namespace);
+
+    if pos + name.len() < BLOCK_SIZE {
+        block[pos..pos+name.len()].copy_from_slice(name);
+        pos += name.len();
+    } else {
+        let (l, r) = name.split_at(BLOCK_SIZE - pos);
+        name = r;
+        block[pos..].copy_from_slice(l);
+        compress(&mut state, &block);
+
+        while name.len() >= BLOCK_SIZE {
+            let (l, r) = name.split_at(BLOCK_SIZE);
+            name = r;
+            compress(&mut state, l);
+        }
+
+        block = [0u8; BLOCK_SIZE];
+        pos = name.len();
+        block[..pos].copy_from_slice(name);
+    }
+
+    block[pos] = 0x80;
+
+    if pos + 1 < 8 {
+        compress(&mut state, &block);
+        block = [0u8; BLOCK_SIZE];
+    }
+
+    let size = ((namespace.len() as u64) + (name.len() as u64)) << 3;
+    for i in 0..8 {
+        block[56+i] = (size >> (8*i)) as u8;
+    }
+    compress(&mut state, &block);
+
+    let mut res = [0u8; 16];
+    for i in 0..4 {
+        res[4*i] = state[i] as u8;
+        res[4*i + 1] = (state[i] >> 8) as u8;
+        res[4*i + 2] = (state[i] >> 16) as u8;
+        res[4*i + 3] = (state[i] >> 24) as u8;
+    }
+    res
+}

--- a/src/md5.rs
+++ b/src/md5.rs
@@ -163,6 +163,7 @@ fn compress(state: &mut [u32; 4], input: &[u8]) {
 
 /// Compute MD5 hash of concatenated namespace and name
 pub fn compute(namespace: &[u8; 16], name: &str) -> [u8; 16] {
+    let size = ((namespace.len() as u64) + (name.len() as u64)) << 3;
     let mut name = name.as_bytes();
     let mut state = S0;
     let mut block = [0u8; BLOCK_SIZE];
@@ -191,13 +192,13 @@ pub fn compute(namespace: &[u8; 16], name: &str) -> [u8; 16] {
     }
 
     block[pos] = 0x80;
+    pos += 1;
 
-    if pos + 1 < 8 {
+    if BLOCK_SIZE - pos < 8 {
         compress(&mut state, &block);
         block = [0u8; BLOCK_SIZE];
     }
 
-    let size = ((namespace.len() as u64) + (name.len() as u64)) << 3;
     for i in 0..8 {
         block[56+i] = (size >> (8*i)) as u8;
     }

--- a/src/sha1.rs
+++ b/src/sha1.rs
@@ -1,0 +1,126 @@
+pub const K0: u32 = 0x5A827999u32;
+pub const K1: u32 = 0x6ED9EBA1u32;
+pub const K2: u32 = 0x8F1BBCDCu32;
+pub const K3: u32 = 0xCA62C1D6u32;
+
+pub const H: [u32; 5] = [
+    0x67452301, 0xEFCDAB89, 0x98BADCFE, 0x10325476, 0xC3D2E1F0
+];
+
+const BLOCK_SIZE: usize = 64;
+
+fn compress(state: &mut [u32; 5], block: &[u8]) {
+    assert_eq!(block.len(), 64);
+    let mut words = [0u32; 80];
+
+    for i in 0..16 {
+        let off = i * 4;
+        words[i] = (block[off + 3] as u32) |
+                   ((block[off + 2] as u32) << 8) |
+                   ((block[off + 1] as u32) << 16) |
+                   ((block[off] as u32) << 24);
+    }
+
+    fn ff(b: u32, c: u32, d: u32) -> u32 {
+        d ^ (b & (c ^ d))
+    }
+    fn gg(b: u32, c: u32, d: u32) -> u32 {
+        b ^ c ^ d
+    }
+    fn hh(b: u32, c: u32, d: u32) -> u32 {
+        (b & c) | (d & (b | c))
+    }
+    fn ii(b: u32, c: u32, d: u32) -> u32 {
+        b ^ c ^ d
+    }
+
+    for i in 16..80 {
+        let n = words[i - 3] ^ words[i - 8] ^ words[i - 14] ^ words[i - 16];
+        words[i] = n.rotate_left(1);
+    }
+
+    let mut a = state[0];
+    let mut b = state[1];
+    let mut c = state[2];
+    let mut d = state[3];
+    let mut e = state[4];
+
+    for i in 0..80 {
+        let (f, k) = match i {
+            0...19 => (ff(b, c, d), K0),
+            20...39 => (gg(b, c, d), K1),
+            40...59 => (hh(b, c, d), K2),
+            60...79 => (ii(b, c, d), K3),
+            _ => (0, 0),
+        };
+
+        let tmp = a.rotate_left(5)
+            .wrapping_add(f)
+            .wrapping_add(e)
+            .wrapping_add(k)
+            .wrapping_add(words[i]);
+        e = d;
+        d = c;
+        c = b.rotate_left(30);
+        b = a;
+        a = tmp;
+    }
+
+    state[0] = state[0].wrapping_add(a);
+    state[1] = state[1].wrapping_add(b);
+    state[2] = state[2].wrapping_add(c);
+    state[3] = state[3].wrapping_add(d);
+    state[4] = state[4].wrapping_add(e);
+}
+
+/// Compute SHA1 hash of concatenated namespace and name
+pub fn compute(namespace: &[u8; 16], name: &str) -> [u8; 16] {
+    let mut name = name.as_bytes();
+    let mut state = H;
+    let mut block = [0u8; BLOCK_SIZE];
+    let mut pos = 16;
+
+    block[..pos].copy_from_slice(namespace);
+
+    if pos + name.len() < BLOCK_SIZE {
+        block[pos..pos+name.len()].copy_from_slice(name);
+        pos += name.len();
+    } else {
+        let (l, r) = name.split_at(BLOCK_SIZE - pos);
+        name = r;
+        block[pos..].copy_from_slice(l);
+        compress(&mut state, &block);
+
+        while name.len() >= BLOCK_SIZE {
+            let (l, r) = name.split_at(BLOCK_SIZE);
+            name = r;
+            compress(&mut state, l);
+        }
+
+        block = [0u8; BLOCK_SIZE];
+        pos = name.len();
+        block[..pos].copy_from_slice(name);
+    }
+
+    block[pos] = 0x80;
+
+    if pos + 1 < 8 {
+        compress(&mut state, &block);
+        block = [0u8; BLOCK_SIZE];
+    }
+
+    let size = (((namespace.len() as u64) + (name.len() as u64)) << 3).to_be();
+    for i in 0..8 {
+        block[56+i] = (size >> (8*i)) as u8;
+    }
+    compress(&mut state, &block);
+
+    let mut res = [0u8; 16];
+    for i in 0..4 {
+        res[4*i] = (state[i] >> 24) as u8;
+        res[4*i + 1] = (state[i] >> 16) as u8;
+        res[4*i + 2] = (state[i] >> 8) as u8;
+        res[4*i + 3] = state[i] as u8;
+    }
+    res
+}

--- a/src/sha1.rs
+++ b/src/sha1.rs
@@ -1,76 +1,272 @@
-pub const K0: u32 = 0x5A827999u32;
-pub const K1: u32 = 0x6ED9EBA1u32;
-pub const K2: u32 = 0x8F1BBCDCu32;
-pub const K3: u32 = 0xCA62C1D6u32;
+use core::ops::{Add, BitXor};
 
-pub const H: [u32; 5] = [
+const K0: u32 = 0x5A827999u32;
+const K1: u32 = 0x6ED9EBA1u32;
+const K2: u32 = 0x8F1BBCDCu32;
+const K3: u32 = 0xCA62C1D6u32;
+
+const H: [u32; 5] = [
     0x67452301, 0xEFCDAB89, 0x98BADCFE, 0x10325476, 0xC3D2E1F0
 ];
 
 const BLOCK_SIZE: usize = 64;
 
-fn compress(state: &mut [u32; 5], block: &[u8]) {
-    assert_eq!(block.len(), 64);
-    let mut words = [0u32; 80];
+#[derive(Copy, Clone)]
+#[allow(non_camel_case_types)]
+struct u32x4(u32, u32, u32, u32);
 
-    for i in 0..16 {
-        let off = i * 4;
-        words[i] = (block[off + 3] as u32) |
-                   ((block[off + 2] as u32) << 8) |
-                   ((block[off + 1] as u32) << 16) |
-                   ((block[off] as u32) << 24);
+impl BitXor for u32x4 {
+    type Output = Self;
+
+    fn bitxor(self, rhs: Self) -> Self::Output {
+        u32x4(self.0 ^ rhs.0, self.1 ^ rhs.1, self.2 ^ rhs.2, self.3 ^ rhs.3)
+    }
+}
+
+impl Add for u32x4 {
+    type Output = Self;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        u32x4(
+            self.0.wrapping_add(rhs.0),
+            self.1.wrapping_add(rhs.1),
+            self.2.wrapping_add(rhs.2),
+            self.3.wrapping_add(rhs.3),
+        )
+    }
+}
+
+#[inline]
+fn sha1_first(w0: u32x4) -> u32 {
+    w0.0
+}
+
+#[inline]
+fn sha1_first_add(e: u32, w0: u32x4) -> u32x4 {
+    let u32x4(a, b, c, d) = w0;
+    u32x4(e.wrapping_add(a), b, c, d)
+}
+
+fn sha1msg1(a: u32x4, b: u32x4) -> u32x4 {
+    let u32x4(_, _, w2, w3) = a;
+    let u32x4(w4, w5, _, _) = b;
+    a ^ u32x4(w2, w3, w4, w5)
+}
+
+fn sha1msg2(a: u32x4, b: u32x4) -> u32x4 {
+    let u32x4(x0, x1, x2, x3) = a;
+    let u32x4(_, w13, w14, w15) = b;
+
+    let w16 = (x0 ^ w13).rotate_left(1);
+    let w17 = (x1 ^ w14).rotate_left(1);
+    let w18 = (x2 ^ w15).rotate_left(1);
+    let w19 = (x3 ^ w16).rotate_left(1);
+
+    u32x4(w16, w17, w18, w19)
+}
+
+#[inline]
+fn sha1_first_half(abcd: u32x4, msg: u32x4) -> u32x4 {
+    sha1_first_add(sha1_first(abcd).rotate_left(30), msg)
+}
+
+fn sha1_digest_round_x4(abcd: u32x4, work: u32x4, i: i8) -> u32x4 {
+    const K0V: u32x4 = u32x4(K0, K0, K0, K0);
+    const K1V: u32x4 = u32x4(K1, K1, K1, K1);
+    const K2V: u32x4 = u32x4(K2, K2, K2, K2);
+    const K3V: u32x4 = u32x4(K3, K3, K3, K3);
+
+    match i {
+        0 => sha1rnds4c(abcd, work + K0V),
+        1 => sha1rnds4p(abcd, work + K1V),
+        2 => sha1rnds4m(abcd, work + K2V),
+        3 => sha1rnds4p(abcd, work + K3V),
+        _ => unreachable!("unknown icosaround index"),
+    }
+}
+
+fn sha1rnds4c(abcd: u32x4, msg: u32x4) -> u32x4 {
+    let u32x4(mut a, mut b, mut c, mut d) = abcd;
+    let u32x4(t, u, v, w) = msg;
+    let mut e = 0u32;
+
+    macro_rules! bool3ary_202 {
+        ($a:expr, $b:expr, $c:expr) => (($c ^ ($a & ($b ^ $c))))
+    } // Choose, MD5F, SHA1C
+
+    e = e.wrapping_add(a.rotate_left(5))
+        .wrapping_add(bool3ary_202!(b, c, d))
+        .wrapping_add(t);
+    b = b.rotate_left(30);
+
+    d = d.wrapping_add(e.rotate_left(5))
+        .wrapping_add(bool3ary_202!(a, b, c))
+        .wrapping_add(u);
+    a = a.rotate_left(30);
+
+    c = c.wrapping_add(d.rotate_left(5))
+        .wrapping_add(bool3ary_202!(e, a, b))
+        .wrapping_add(v);
+    e = e.rotate_left(30);
+
+    b = b.wrapping_add(c.rotate_left(5))
+        .wrapping_add(bool3ary_202!(d, e, a))
+        .wrapping_add(w);
+    d = d.rotate_left(30);
+
+    u32x4(b, c, d, e)
+}
+
+fn sha1rnds4p(abcd: u32x4, msg: u32x4) -> u32x4 {
+    let u32x4(mut a, mut b, mut c, mut d) = abcd;
+    let u32x4(t, u, v, w) = msg;
+    let mut e = 0u32;
+
+    macro_rules! bool3ary_150 {
+        ($a:expr, $b:expr, $c:expr) => (($a ^ $b ^ $c))
+    } // Parity, XOR, MD5H, SHA1P
+
+    e = e.wrapping_add(a.rotate_left(5))
+        .wrapping_add(bool3ary_150!(b, c, d))
+        .wrapping_add(t);
+    b = b.rotate_left(30);
+
+    d = d.wrapping_add(e.rotate_left(5))
+        .wrapping_add(bool3ary_150!(a, b, c))
+        .wrapping_add(u);
+    a = a.rotate_left(30);
+
+    c = c.wrapping_add(d.rotate_left(5))
+        .wrapping_add(bool3ary_150!(e, a, b))
+        .wrapping_add(v);
+    e = e.rotate_left(30);
+
+    b = b.wrapping_add(c.rotate_left(5))
+        .wrapping_add(bool3ary_150!(d, e, a))
+        .wrapping_add(w);
+    d = d.rotate_left(30);
+
+    u32x4(b, c, d, e)
+}
+
+fn sha1rnds4m(abcd: u32x4, msg: u32x4) -> u32x4 {
+    let u32x4(mut a, mut b, mut c, mut d) = abcd;
+    let u32x4(t, u, v, w) = msg;
+    let mut e = 0u32;
+
+    macro_rules! bool3ary_232 {
+        ($a:expr, $b:expr, $c:expr) => (($a & $b) ^ ($a & $c) ^ ($b & $c))
+    } // Majority, SHA1M
+
+    e = e.wrapping_add(a.rotate_left(5))
+        .wrapping_add(bool3ary_232!(b, c, d))
+        .wrapping_add(t);
+    b = b.rotate_left(30);
+
+    d = d.wrapping_add(e.rotate_left(5))
+        .wrapping_add(bool3ary_232!(a, b, c))
+        .wrapping_add(u);
+    a = a.rotate_left(30);
+
+    c = c.wrapping_add(d.rotate_left(5))
+        .wrapping_add(bool3ary_232!(e, a, b))
+        .wrapping_add(v);
+    e = e.rotate_left(30);
+
+    b = b.wrapping_add(c.rotate_left(5))
+        .wrapping_add(bool3ary_232!(d, e, a))
+        .wrapping_add(w);
+    d = d.rotate_left(30);
+
+    u32x4(b, c, d, e)
+}
+
+fn sha1_digest_block_u32(state: &mut [u32; 5], block: &[u32; 16]) {
+
+    macro_rules! schedule {
+        ($v0:expr, $v1:expr, $v2:expr, $v3:expr) => (
+            sha1msg2(sha1msg1($v0, $v1) ^ $v2, $v3)
+        )
     }
 
-    fn ff(b: u32, c: u32, d: u32) -> u32 {
-        d ^ (b & (c ^ d))
-    }
-    fn gg(b: u32, c: u32, d: u32) -> u32 {
-        b ^ c ^ d
-    }
-    fn hh(b: u32, c: u32, d: u32) -> u32 {
-        (b & c) | (d & (b | c))
-    }
-    fn ii(b: u32, c: u32, d: u32) -> u32 {
-        b ^ c ^ d
+    macro_rules! rounds4 {
+        ($h0:ident, $h1:ident, $wk:expr, $i:expr) => (
+            sha1_digest_round_x4($h0, sha1_first_half($h1, $wk), $i)
+        )
     }
 
-    for i in 16..80 {
-        let n = words[i - 3] ^ words[i - 8] ^ words[i - 14] ^ words[i - 16];
-        words[i] = n.rotate_left(1);
-    }
+    // Rounds 0..20
+    let mut h0 = u32x4(state[0], state[1], state[2], state[3]);
+    let mut w0 = u32x4(block[0], block[1], block[2], block[3]);
+    let mut h1 = sha1_digest_round_x4(h0, sha1_first_add(state[4], w0), 0);
+    let mut w1 = u32x4(block[4], block[5], block[6], block[7]);
+    h0 = rounds4!(h1, h0, w1, 0);
+    let mut w2 = u32x4(block[8], block[9], block[10], block[11]);
+    h1 = rounds4!(h0, h1, w2, 0);
+    let mut w3 = u32x4(block[12], block[13], block[14], block[15]);
+    h0 = rounds4!(h1, h0, w3, 0);
+    let mut w4 = schedule!(w0, w1, w2, w3);
+    h1 = rounds4!(h0, h1, w4, 0);
 
-    let mut a = state[0];
-    let mut b = state[1];
-    let mut c = state[2];
-    let mut d = state[3];
-    let mut e = state[4];
+    // Rounds 20..40
+    w0 = schedule!(w1, w2, w3, w4);
+    h0 = rounds4!(h1, h0, w0, 1);
+    w1 = schedule!(w2, w3, w4, w0);
+    h1 = rounds4!(h0, h1, w1, 1);
+    w2 = schedule!(w3, w4, w0, w1);
+    h0 = rounds4!(h1, h0, w2, 1);
+    w3 = schedule!(w4, w0, w1, w2);
+    h1 = rounds4!(h0, h1, w3, 1);
+    w4 = schedule!(w0, w1, w2, w3);
+    h0 = rounds4!(h1, h0, w4, 1);
 
-    for i in 0..80 {
-        let (f, k) = match i {
-            0...19 => (ff(b, c, d), K0),
-            20...39 => (gg(b, c, d), K1),
-            40...59 => (hh(b, c, d), K2),
-            60...79 => (ii(b, c, d), K3),
-            _ => (0, 0),
-        };
+    // Rounds 40..60
+    w0 = schedule!(w1, w2, w3, w4);
+    h1 = rounds4!(h0, h1, w0, 2);
+    w1 = schedule!(w2, w3, w4, w0);
+    h0 = rounds4!(h1, h0, w1, 2);
+    w2 = schedule!(w3, w4, w0, w1);
+    h1 = rounds4!(h0, h1, w2, 2);
+    w3 = schedule!(w4, w0, w1, w2);
+    h0 = rounds4!(h1, h0, w3, 2);
+    w4 = schedule!(w0, w1, w2, w3);
+    h1 = rounds4!(h0, h1, w4, 2);
 
-        let tmp = a.rotate_left(5)
-            .wrapping_add(f)
-            .wrapping_add(e)
-            .wrapping_add(k)
-            .wrapping_add(words[i]);
-        e = d;
-        d = c;
-        c = b.rotate_left(30);
-        b = a;
-        a = tmp;
-    }
+    // Rounds 60..80
+    w0 = schedule!(w1, w2, w3, w4);
+    h0 = rounds4!(h1, h0, w0, 3);
+    w1 = schedule!(w2, w3, w4, w0);
+    h1 = rounds4!(h0, h1, w1, 3);
+    w2 = schedule!(w3, w4, w0, w1);
+    h0 = rounds4!(h1, h0, w2, 3);
+    w3 = schedule!(w4, w0, w1, w2);
+    h1 = rounds4!(h0, h1, w3, 3);
+    w4 = schedule!(w0, w1, w2, w3);
+    h0 = rounds4!(h1, h0, w4, 3);
+
+    let e = sha1_first(h1).rotate_left(30);
+    let u32x4(a, b, c, d) = h0;
 
     state[0] = state[0].wrapping_add(a);
     state[1] = state[1].wrapping_add(b);
     state[2] = state[2].wrapping_add(c);
     state[3] = state[3].wrapping_add(d);
     state[4] = state[4].wrapping_add(e);
+}
+
+fn compress(state: &mut [u32; 5], block: &[u8]) {
+    assert_eq!(block.len(), 64);
+    let mut block_u32 = [0u32; 16];
+
+    for i in 0..16 {
+        let off = i * 4;
+        block_u32[i] = (block[off + 3] as u32) |
+                       ((block[off + 2] as u32) << 8) |
+                       ((block[off + 1] as u32) << 16) |
+                       ((block[off] as u32) << 24);
+    }
+
+    sha1_digest_block_u32(state, &block_u32);
 }
 
 /// Compute SHA1 hash of concatenated namespace and name

--- a/src/sha1.rs
+++ b/src/sha1.rs
@@ -75,6 +75,7 @@ fn compress(state: &mut [u32; 5], block: &[u8]) {
 
 /// Compute SHA1 hash of concatenated namespace and name
 pub fn compute(namespace: &[u8; 16], name: &str) -> [u8; 16] {
+    let size = (((namespace.len() as u64) + (name.len() as u64)) << 3).to_be();
     let mut name = name.as_bytes();
     let mut state = H;
     let mut block = [0u8; BLOCK_SIZE];
@@ -103,13 +104,13 @@ pub fn compute(namespace: &[u8; 16], name: &str) -> [u8; 16] {
     }
 
     block[pos] = 0x80;
+    pos += 1;
 
-    if pos + 1 < 8 {
+    if BLOCK_SIZE - pos < 8 {
         compress(&mut state, &block);
         block = [0u8; BLOCK_SIZE];
     }
 
-    let size = (((namespace.len() as u64) + (name.len() as u64)) << 3).to_be();
     for i in 0..8 {
         block[56+i] = (size >> (8*i)) as u8;
     }


### PR DESCRIPTION
Crates from RustCrypto share the same interface and faster than `md5` (426 MB/s vs 336 MB/s) and `sha1` (490 MB/s vs 200 MB/s). And in future they could be even faster. (by [improving](https://github.com/rust-lang/rust/issues/41894) LLVM for MD5 and through hardware acceleration for SHA-1) For `uuid` it's probably not that important, but still improvement nevertheless.

The only drawback is that they depend on `typenum` (due to generic interfaces), but hopefully in future with the introduction of type-level integers this dependency will be removed.