### PR TITLE
Avoid doing character decoding when parsing uuids

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -631,7 +631,7 @@ impl Uuid {
         let mut acc = 0;
         let mut buffer = [0u8; 16];
 
-        for (i_char, chr) in input.chars().enumerate() {
+        for (i_char, chr) in input.bytes().enumerate() {
             if digit as usize >= SIMPLE_LENGTH && group != 4 {
                 if group == 0 {
                     return Err(ParseError::InvalidLength(len));
@@ -643,11 +643,11 @@ impl Uuid {
                 // First digit of the byte.
                 match chr {
                     // Calulate upper half.
-                    '0'...'9' => acc = chr as u8 - '0' as u8,
-                    'a'...'f' => acc = chr as u8 - 'a' as u8 + 10,
-                    'A'...'F' => acc = chr as u8 - 'A' as u8 + 10,
+                    b'0'...b'9' => acc = chr - b'0',
+                    b'a'...b'f' => acc = chr - b'a' + 10,
+                    b'A'...b'F' => acc = chr - b'A' + 10,
                     // Found a group delimiter
-                    '-' => {
+                    b'-' => {
                         if ACC_GROUP_LENS[group] != digit {
                             // Calculate how many digits this group consists of in the input.
                             let found = if group > 0 {
@@ -663,16 +663,16 @@ impl Uuid {
                         group += 1;
                         digit -= 1;
                     }
-                    _ => return Err(ParseError::InvalidCharacter(chr, i_char)),
+                    _ => return Err(ParseError::InvalidCharacter(input[i_char..].chars().next().unwrap(), i_char)),
                 }
             } else {
                 // Second digit of the byte, shift the upper half.
                 acc *= 16;
                 match chr {
-                    '0'...'9' => acc += chr as u8 - '0' as u8,
-                    'a'...'f' => acc += chr as u8 - 'a' as u8 + 10,
-                    'A'...'F' => acc += chr as u8 - 'A' as u8 + 10,
-                    '-' => {
+                    b'0'...b'9' => acc += chr - b'0',
+                    b'a'...b'f' => acc += chr - b'a' + 10,
+                    b'A'...b'F' => acc += chr - b'A' + 10,
+                    b'-' => {
                         // The byte isn't complete yet.
                         let found = if group > 0 {
                             digit - ACC_GROUP_LENS[group - 1]
@@ -683,7 +683,7 @@ impl Uuid {
                                                                   found as usize,
                                                                   GROUP_LENS[group]));
                     }
-                    _ => return Err(ParseError::InvalidCharacter(chr, i_char)),
+                    _ => return Err(ParseError::InvalidCharacter(input[i_char..].chars().next().unwrap(), i_char)),
                 }
                 buffer[(digit / 2) as usize] = acc;
             }


### PR DESCRIPTION
Valid UUIDs are always ascii so we can avoid doing the decoding unless
we encounter a byte that is not a valid character.

```
 name                           orig ns/iter  new ns/iter  diff ns/iter   diff %  speedup
 bench_parse                    1,832         1,407                -425  -23.20%   x 1.30
 bench_parse_invalid_character  71            64                     -7   -9.86%   x 1.11
 bench_parse_invalid_group_len  102           80                    -22  -21.57%   x 1.27
 bench_parse_invalid_groups     123           100                   -23  -18.70%   x 1.23
 bench_parse_invalid_len        2             2                       0    0.00%   x 1.00
 bench_valid_hyphenated         116           96                    -20  -17.24%   x 1.21
 bench_valid_short              98            78                    -20  -20.41%   x 1.26

```