### PR TITLE
Try to avoid allocating a String when serializing

### DIFF
--- a/src/serde.rs
+++ b/src/serde.rs
@@ -9,7 +9,7 @@ use Uuid;
 
 impl Serialize for Uuid {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        serializer.serialize_str(&self.hyphenated().to_string())
+        serializer.collect_str(&self.hyphenated())
     }
 }
 


### PR DESCRIPTION
... if the serializer supports it. Missed adding this in the previous PR

https://docs.rs/serde/1.0.8/serde/trait.Serializer.html#method.collect_str