### PR TITLE
Eliminate a use of copy_memory

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -419,9 +419,7 @@ impl Uuid {
         let mut ctx = md5::Context::new();
         ctx.consume(namespace.as_bytes());
         ctx.consume(name.as_bytes());
-        let digest = ctx.compute();
-        let mut uuid = Uuid { bytes: [0; 16] };
-        copy_memory(&mut uuid.bytes, &digest[..16]);
+        let mut uuid = Uuid { bytes: ctx.compute().into() };
         uuid.set_variant(UuidVariant::RFC4122);
         uuid.set_version(UuidVersion::Md5);
         uuid


### PR DESCRIPTION
It’s to avoid memory initialization before copying the digest.