### PR TITLE
Serialize to binary if the serde format is not human readable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ md5 = { version = "0.3", optional = true }
 
 [dev-dependencies]
 serde_json = "1.0"
-serde_test = "1.0.16"
 
 [features]
 use_std = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,13 +17,14 @@ all-features = true
 
 [dependencies]
 rustc-serialize = { version = "0.3", optional = true }
-serde = { version = "1.0", optional = true }
+serde = { version = "1.0.16", optional = true }
 rand = { version = "0.3", optional = true }
 sha1 = { version = "0.2", optional = true }
 md5 = { version = "0.3", optional = true }
 
 [dev-dependencies]
 serde_json = "1.0"
+serde_test = "1.0.16"
 
 [features]
 use_std = []

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -63,19 +63,8 @@ impl<'de> Deserialize<'de> for Uuid {
 #[cfg(test)]
 mod tests {
     extern crate serde_json;
-    extern crate serde_test;
-
-    use self::serde_test::Token;
 
     use Uuid;
-
-    #[test]
-    fn test_str() {
-        let str_uuid = "67e55044-10b1-426f-9247-bb680e5fe0c8";
-        let uuid = Uuid::parse_str(str_uuid).unwrap();
-
-        serde_test::assert_tokens(&uuid, &[Token::BorrowedStr(str_uuid)]);
-    }
 
     #[test]
     fn test_serialize_round_trip() {


### PR DESCRIPTION
This uses the
[is_human_readable](https://github.com/serde-rs/serde/releases/tag/v1.0.16)
method added in serde 1.0.16 to serialize uuid's in a more compact
form if the serialized format does not need to be human readable.

This does not have an explicit test for `is_human_readable == false` since https://github.com/serde-rs/serde/issues/1065 has not been completed for serde_test so you may want to wait with merging. I have verified it manually though.

(Maybe?) related #90