### PR TITLE
Add tests for compact/readable representations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ sha1 = { version = "0.2", optional = true }
 md5 = { version = "0.3", optional = true }
 
 [dev-dependencies]
-serde_json = "1.0"
+serde_test = "1.0.19"
 
 [features]
 use_std = []

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -62,15 +62,23 @@ impl<'de> Deserialize<'de> for Uuid {
 
 #[cfg(test)]
 mod tests {
-    extern crate serde_json;
+    extern crate serde_test;
+
+    use self::serde_test::{Configure, Token, assert_tokens};
 
     use Uuid;
 
     #[test]
-    fn test_serialize_round_trip() {
-        let u = Uuid::parse_str("F9168C5E-CEB2-4FAA-B6BF-329BF39FA1E4").unwrap();
-        let s = serde_json::to_string(&u).unwrap();
-        let u2 = serde_json::from_str(&s).unwrap();
-        assert_eq!(u, u2);
+    fn test_serialize_readable() {
+        let uuid_str = "f9168c5e-ceb2-4faa-b6bf-329bf39fa1e4";
+        let u = Uuid::parse_str(uuid_str).unwrap();
+        assert_tokens(&u.readable(), &[Token::Str(uuid_str)]);
+    }
+
+    #[test]
+    fn test_serialize_compact() {
+        let uuid_bytes = b"F9168C5E-CEB2-4F";
+        let u = Uuid::from_bytes(uuid_bytes).unwrap();
+        assert_tokens(&u.compact(), &[Token::Bytes(uuid_bytes)]);
     }
 }


### PR DESCRIPTION
Ended up completing the compact/readable serde_test API so here are the
tests missing from https://github.com/rust-lang-nursery/uuid/pull/104.

I also replaced the `serde_json` roundtrip test with plain `assert_tokens`
tests which do essentially the same thing. I can re-add it if it seems
worthwhile to keep it though.