### PR TITLE
Rename `use_std` feature to `std`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,12 @@ matrix:
     - env: FEATURES=""
     - env: FEATURES="rustc-serialize"
     - env: FEATURES="serde"
-    - env: FEATURES="use_std"
+    - env: FEATURES="std"
     - env: FEATURES="v1"
     - env: FEATURES="v3"
     - env: FEATURES="v4"
     - env: FEATURES="v5"
-    - env: FEATURES="rustc-serialize serde v1 v3 v4 v5 use_std"
+    - env: FEATURES="rustc-serialize serde v1 v3 v4 v5 std"
     - rust: beta
     - rust: nightly
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,8 @@ md5 = { version = "0.3", optional = true }
 serde_test = "1.0.19"
 
 [features]
-use_std = []
+std = []
+use_std = ["std"] # deprecated, equivalent to `std`
 v1 = ["rand"]
 v3 = ["md5"]
 v4 = ["rand"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@
 //! The following Cargo features, however, can be used to enable various pieces
 //! of functionality.
 //!
-//! * `use_std` - adds in functionality available when linking to the standard
+//! * `std` - adds in functionality available when linking to the standard
 //!   library, currently this is only the `impl Error for ParseError`.
 //! * `v1` - adds the `Uuid::new_v1` function and the ability to create a V1
 //!   using a `UUIDV1Context` and a timestamp from `time::timespec`
@@ -121,7 +121,7 @@ use core::str::FromStr;
 
 // rustc-serialize and serde link to std, so go ahead an pull in our own std
 // support in those situations as well.
-#[cfg(any(feature = "use_std",
+#[cfg(any(feature = "std",
           feature = "rustc-serialize",
           feature = "serde"))]
 mod std_support;


### PR DESCRIPTION
The `use_std` feature remains for backwards compatibility.

Fixes #107.